### PR TITLE
Update tests for pytest 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ lib64
 pip-log.txt
 
 # Unit test / coverage reports
+junit.xml
+coverage.xml
 .coverage
 .tox
 .cache/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest<8.0
+pytest
 pytest-cov
 flake8
 coverage

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -11,8 +11,10 @@ NO_TAGS = None
 
 
 class TestStatsdDefaultClient(object):
-    def setup(self):
-        self.tags = ['StatsClient_doesnt_do_tags!']
+    tags = ['StatsClient_doesnt_do_tags!']
+
+    @pytest.fixture(autouse=True)
+    def client_configure(self):
         statsdecor.configure(vendor='')
 
     @patch('statsd.client.StatsClient.incr')
@@ -60,9 +62,11 @@ class TestStatsdDefaultClient(object):
 
 
 class TestDogStatsdClient(object):
-    def setup(self):
-        self.tags = ['DogStatsd_does_tags!']
-        self.vendor = 'datadog'
+    tags = ['DogStatsd_does_tags!']
+    vendor = 'datadog'
+
+    @pytest.fixture(autouse=True)
+    def client_configure(self):
         statsdecor.configure(vendor=self.vendor)
 
     @patch('datadog.dogstatsd.DogStatsd.increment')

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,3 +1,4 @@
+import pytest
 from mock import patch
 
 import statsdecor
@@ -31,12 +32,12 @@ class _TestException(Exception):
 
 
 class TestStatsContext(object):
-    def setup(self):
-        self.tags = ['DogStatsd_does_tags!']
-        self.vendor = 'datadog'
+    tags = ['DogStatsd_does_tags!']
+    vendor = 'datadog'
+
+    @pytest.fixture(autouse=True)
+    def client_configure(self):
         statsdecor.configure(vendor=self.vendor)
-        # DELETE me
-        self.mock_current_app = None
 
     @patch('datadog.dogstatsd.DogStatsd.increment')
     @patch('datadog.dogstatsd.DogStatsd.timing')

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,12 +1,10 @@
-import statsdecor.decorators as decorators
-import statsdecor
-from tests.conftest import stub_client
+import pytest
 from mock import MagicMock
-from statsdecor.clients import (
-    DogStatsdClient,
-    StatsdClient
-)
 
+import statsdecor
+import statsdecor.decorators as decorators
+from statsdecor.clients import DogStatsdClient, StatsdClient
+from tests.conftest import stub_client
 
 NO_TAGS = None
 
@@ -78,15 +76,19 @@ class BaseDecoratorTestCase(object):
 
 
 class TestStatsdDefaultClient(BaseDecoratorTestCase):
-    def setup(self):
-        self.tags = ['StatsClient_doesnt_do_tags!']
-        self.client_class = StatsdClient
+    tags = ['StatsClient_doesnt_do_tags!']
+    client_class = StatsdClient
+
+    @pytest.fixture(autouse=True)
+    def client_configure(self):
         statsdecor.configure()
 
 
 class TestDogStatsdClient(BaseDecoratorTestCase):
-    def setup(self):
-        self.tags = ['DogStatsd_does_tags!']
-        self.vendor = 'datadog'
-        self.client_class = DogStatsdClient
+    tags = ['DogStatsd_does_tags!']
+    vendor = 'datadog'
+    client_class = DogStatsdClient
+
+    @pytest.fixture(autouse=True)
+    def client_configure(self):
         statsdecor.configure(vendor=self.vendor)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,11 +1,10 @@
-import statsdecor
+import pytest
 import statsd
 from datadog import DogStatsd
+
+import statsdecor
+from statsdecor.clients import DogStatsdClient, StatsdClient
 from tests.conftest import stub_client
-from statsdecor.clients import (
-    DogStatsdClient,
-    StatsdClient
-)
 
 
 class BaseFunctionTestCase(object):
@@ -69,8 +68,10 @@ class BaseFunctionTestCase(object):
 
 
 class TestStatsdDefaultClient(BaseFunctionTestCase):
-    def setup(self):
-        self.client_class = StatsdClient
+    client_class = StatsdClient
+
+    @pytest.fixture(autouse=True)
+    def client_configure(self):
         statsdecor.configure(vendor='')
 
     def test_client_created_if_no_existing_client__with_no_config(self, monkeypatch):
@@ -97,9 +98,11 @@ class TestStatsdDefaultClient(BaseFunctionTestCase):
 
 
 class TestDogStatsdClient(BaseFunctionTestCase):
-    def setup(self):
-        self.vendor = 'datadog'
-        self.client_class = DogStatsdClient
+    client_class = DogStatsdClient
+    vendor = 'datadog'
+
+    @pytest.fixture(autouse=True)
+    def client_configure(self):
         statsdecor.configure(vendor=self.vendor)
 
     def test_configure_and_create(self):


### PR DESCRIPTION
It appears that the classic nose `setup` fixture methods no longer work on pytest 8.0 as they are not executing. Rewriting the tests to use proper pytest fixtures.